### PR TITLE
removed duplicate dependencies in NiFi's parent pom.xml

### DIFF
--- a/nifi/pom.xml
+++ b/nifi/pom.xml
@@ -841,16 +841,6 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>2.4.5</version>
             </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>2.4.5</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.4.5</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>


### PR DESCRIPTION
During previous merge the dependencies for jackson was added twice. This pull request removes the duplicates
