### PR TITLE
Null safe check on the sorters to avoid NPEs

### DIFF
--- a/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/NullSafeComparator.java
+++ b/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/NullSafeComparator.java
@@ -1,0 +1,19 @@
+package org.apache.nifi.web.util;
+
+import java.util.Comparator;
+
+public class NullSafeComparator<E extends Comparable<E>> implements Comparator<E> {
+
+	@Override
+	public int compare(E o1, E o2) {
+		if(null == o1 ^ null == o2) {
+			return (o1 == null) ? -1 : 1;
+		}
+
+		if(null == o1 && null == o2) {
+			return 0;
+		}
+
+		return o1.compareTo(o2);
+	}
+}

--- a/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/Sorters.java
+++ b/nifi/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/Sorters.java
@@ -12,37 +12,49 @@ import org.apache.nifi.groups.RemoteProcessGroup;
 
 public class Sorters {
 
+	public static NullSafeComparator<String> nullSafeStringComparator = new NullSafeComparator<String>();
+	public static int nullSafeCompare(String o1, String o2) {
+		return nullSafeStringComparator.compare(o1, o2);
+	}
+
 	public static ArrayList<Port> sortPorts(ArrayList<Port> list) {
 		Collections.sort(list, new Comparator<Port>() {
 
 			@Override
-			public int compare(Port o1, Port o2) {
-				return o1.getName().compareTo(o2.getName());
+			public int compare(final Port o1, final Port o2) {
+				String s1 = (null != o1)? o1.getName() : null;
+				String s2 = (null != o2)? o2.getName() : null;
+
+				return nullSafeCompare(s1, s2);
 			}
 		});
 
 		return list;
 	}
 
-	public static ArrayList<RemoteProcessGroup> sortRemoteProcessGroups(
-			ArrayList<RemoteProcessGroup> list) {
+	public static ArrayList<RemoteProcessGroup> sortRemoteProcessGroups(ArrayList<RemoteProcessGroup> list) {
 		Collections.sort(list, new Comparator<RemoteProcessGroup>() {
 
 			@Override
 			public int compare(RemoteProcessGroup o1, RemoteProcessGroup o2) {
-				return o1.getName().compareTo(o2.getName());
+				String s1 = (null != o1)? o1.getName() : null;
+				String s2 = (null != o2)? o2.getName() : null;
+
+				return nullSafeCompare(s1, s2);
 			}
 		});
 		return list;
 	}
 
-	public static ArrayList<ProcessorNode> sortProcessorNodes(
-			ArrayList<ProcessorNode> list) {
+	public static ArrayList<ProcessorNode> sortProcessorNodes(ArrayList<ProcessorNode> list) {
 		Collections.sort(list, new Comparator<ProcessorNode>() {
 
 			@Override
 			public int compare(ProcessorNode o1, ProcessorNode o2) {
-				return o1.getName().compareTo(o2.getName());
+				String s1 = (null != o1)? o1.getName() : null;
+				String s2 = (null != o2)? o2.getName() : null;
+
+				return nullSafeCompare(s1, s2);
 			}
 		});
 		return list;
@@ -53,19 +65,24 @@ public class Sorters {
 
 			@Override
 			public int compare(Label o1, Label o2) {
-				return o1.getValue().compareTo(o2.getValue());
+				String s1 = (null != o1)? o1.getValue() : null;
+				String s2 = (null != o2)? o2.getValue() : null;
+
+				return nullSafeCompare(s1, s2);
 			}
 		});
 		return list;
 	}
 
-	public static ArrayList<ProcessGroup> sortProcessGroups(
-			ArrayList<ProcessGroup> list) {
+	public static ArrayList<ProcessGroup> sortProcessGroups(ArrayList<ProcessGroup> list) {
 		Collections.sort(list, new Comparator<ProcessGroup>() {
 
 			@Override
 			public int compare(ProcessGroup o1, ProcessGroup o2) {
-				return o1.getName().compareTo(o2.getName());
+				String s1 = (null != o1)? o1.getName() : null;
+				String s2 = (null != o2)? o2.getName() : null;
+
+				return nullSafeCompare(s1, s2);
 			}
 		});
 		return list;


### PR DESCRIPTION
After I loaded Nifi and imported the wildfire template, I tried to double click into the processor groups and got an NPE. It was coming from the new Sorters being applied to the template elements (probably cause it's always sorting even when you aren't exporting). I noticed that the sorter isn't being defensive about null objects, so NPEs will happen if objects or values are null. Fixed it, redeployed it, and it seems to be working fine now.
