### PR TITLE
[A-1390] Ported NIFI-1025 pom changes to resolve aws/joda-time/jdk bug

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/pom.xml
@@ -30,14 +30,4 @@
         <module>nifi-aws-nar</module>
     </modules>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk</artifactId>
-                <version>1.9.24</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.8</version>
+                <version>2.8.2</version>
             </dependency>
             <dependency>
                 <groupId>com.yammer.metrics</groupId>
@@ -977,6 +977,11 @@
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derby</artifactId>
                 <version>10.11.1.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk</artifactId>
+                <version>1.10.32</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Changes affect the AWS nar, which wildfire does not currently use, along with a minor upgrade to joda-time.
