### PR TITLE
[A-1661] Set version to 0.4.1-A-SNAPSHOT

### DIFF
--- a/nifi-api/pom.xml
+++ b/nifi-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-api</artifactId>
     <packaging>jar</packaging>    

--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -14,7 +14,7 @@ language governing permissions and limitations under the License. -->
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-assembly</artifactId>
     <packaging>pom</packaging>

--- a/nifi-bootstrap/pom.xml
+++ b/nifi-bootstrap/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.apache.nifi</groupId>
 		<artifactId>nifi</artifactId>
-		<version>0.4.1</version>
+		<version>0.4.1-A-SNAPSHOT</version>
 	</parent>
 	<artifactId>nifi-bootstrap</artifactId>
 	<packaging>jar</packaging>

--- a/nifi-commons/nifi-data-provenance-utils/pom.xml
+++ b/nifi-commons/nifi-data-provenance-utils/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-data-provenance-utils</artifactId>
     <packaging>jar</packaging>

--- a/nifi-commons/nifi-expression-language/pom.xml
+++ b/nifi-commons/nifi-expression-language/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-expression-language</artifactId>
     <packaging>jar</packaging>

--- a/nifi-commons/nifi-flowfile-packager/pom.xml
+++ b/nifi-commons/nifi-flowfile-packager/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-flowfile-packager</artifactId>
     <packaging>jar</packaging>

--- a/nifi-commons/nifi-hl7-query-language/pom.xml
+++ b/nifi-commons/nifi-hl7-query-language/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-hl7-query-language</artifactId>

--- a/nifi-commons/nifi-logging-utils/pom.xml
+++ b/nifi-commons/nifi-logging-utils/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-logging-utils</artifactId>
     <description>Utilities for logging</description>

--- a/nifi-commons/nifi-processor-utilities/pom.xml
+++ b/nifi-commons/nifi-processor-utilities/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-processor-utils</artifactId>
     <packaging>jar</packaging>

--- a/nifi-commons/nifi-properties/pom.xml
+++ b/nifi-commons/nifi-properties/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-properties</artifactId>
 </project>

--- a/nifi-commons/nifi-security-utils/pom.xml
+++ b/nifi-commons/nifi-security-utils/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-security-utils</artifactId>
     <description>Contains security functionality.</description>

--- a/nifi-commons/nifi-site-to-site-client/pom.xml
+++ b/nifi-commons/nifi-site-to-site-client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-site-to-site-client</artifactId>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-client-dto</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/nifi-commons/nifi-socket-utils/pom.xml
+++ b/nifi-commons/nifi-socket-utils/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-socket-utils</artifactId>
     <description>Utilities for socket communication</description>

--- a/nifi-commons/nifi-utils/pom.xml
+++ b/nifi-commons/nifi-utils/pom.xml
@@ -18,10 +18,10 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-utils</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>jar</packaging>
     <!--
     This project intentionally has no additional dependencies beyond that pulled in by the parent.  It is a general purpose utility library

--- a/nifi-commons/nifi-web-utils/pom.xml
+++ b/nifi-commons/nifi-web-utils/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-web-utils</artifactId>
     <dependencies>

--- a/nifi-commons/nifi-write-ahead-log/pom.xml
+++ b/nifi-commons/nifi-write-ahead-log/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-commons</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-write-ahead-log</artifactId>
     <packaging>jar</packaging>

--- a/nifi-commons/pom.xml
+++ b/nifi-commons/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-commons</artifactId>

--- a/nifi-docs/pom.xml
+++ b/nifi-docs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <artifactId>nifi-docs</artifactId>

--- a/nifi-external/nifi-example-bundle/nifi-nifi-example-nar/pom.xml
+++ b/nifi-external/nifi-example-bundle/nifi-nifi-example-nar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-example-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-example-nar</artifactId>

--- a/nifi-external/nifi-example-bundle/nifi-nifi-example-processors/pom.xml
+++ b/nifi-external/nifi-example-bundle/nifi-nifi-example-processors/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-example-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-nifi-example-processors</artifactId>

--- a/nifi-external/nifi-example-bundle/pom.xml
+++ b/nifi-external/nifi-example-bundle/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-external</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-example-bundle</artifactId>
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-nifi-example-processors</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-external/nifi-spark-receiver/pom.xml
+++ b/nifi-external/nifi-spark-receiver/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-external</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-spark-receiver</artifactId>

--- a/nifi-external/nifi-storm-spout/pom.xml
+++ b/nifi-external/nifi-storm-spout/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-external</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-storm-spout</artifactId>

--- a/nifi-external/pom.xml
+++ b/nifi-external/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-external</artifactId>

--- a/nifi-maven-archetypes/nifi-processor-bundle-archetype/pom.xml
+++ b/nifi-maven-archetypes/nifi-processor-bundle-archetype/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-maven-archetypes</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-processor-bundle-archetype</artifactId>

--- a/nifi-maven-archetypes/nifi-service-bundle-archetype/pom.xml
+++ b/nifi-maven-archetypes/nifi-service-bundle-archetype/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-maven-archetypes</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-service-bundle-archetype</artifactId>

--- a/nifi-maven-archetypes/pom.xml
+++ b/nifi-maven-archetypes/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-maven-archetypes</artifactId>

--- a/nifi-mock/pom.xml
+++ b/nifi-mock/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-mock</artifactId>
     <dependencies>

--- a/nifi-nar-bundles/nifi-ambari-bundle/nifi-ambari-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-ambari-bundle/nifi-ambari-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-ambari-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-ambari-nar</artifactId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-ambari-reporting-task</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-ambari-bundle/nifi-ambari-reporting-task/pom.xml
+++ b/nifi-nar-bundles/nifi-ambari-bundle/nifi-ambari-reporting-task/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-ambari-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-ambari-reporting-task</artifactId>

--- a/nifi-nar-bundles/nifi-ambari-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ambari-bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-ambari-bundle</artifactId>

--- a/nifi-nar-bundles/nifi-avro-bundle/nifi-avro-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-avro-bundle/nifi-avro-nar/pom.xml
@@ -19,18 +19,18 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-avro-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-avro-nar</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>nar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-avro-processors</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-avro-bundle/nifi-avro-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-avro-bundle/nifi-avro-processors/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.apache.nifi</groupId>
 		<artifactId>nifi-avro-bundle</artifactId>
-		<version>0.4.1</version>
+		<version>0.4.1-A-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>nifi-avro-processors</artifactId>

--- a/nifi-nar-bundles/nifi-avro-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-avro-bundle/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-avro-bundle</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-nar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-aws-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-aws-nar</artifactId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-aws-processors</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-aws-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-aws-processors</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-aws-bundle</artifactId>

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-nar/pom.xml
@@ -19,18 +19,18 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-azure-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-azure-nar</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>nar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-azure-processors</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.apache.nifi</groupId>
 		<artifactId>nifi-azure-bundle</artifactId>
-		<version>0.4.1</version>
+		<version>0.4.1-A-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>nifi-azure-processors</artifactId>

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-azure-bundle</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-nar/pom.xml
@@ -19,18 +19,18 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-couchbase-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-couchbase-nar</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>nar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-couchbase-processors</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-couchbase-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-couchbase-processors</artifactId>

--- a/nifi-nar-bundles/nifi-couchbase-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-couchbase-bundle/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-couchbase-bundle</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/nifi-nar-bundles/nifi-flume-bundle/nifi-flume-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-flume-bundle/nifi-flume-nar/pom.xml
@@ -18,10 +18,10 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-flume-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-flume-nar</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>nar</packaging>
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-flume-bundle/nifi-flume-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-flume-bundle/nifi-flume-processors/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-flume-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-flume-processors</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-flume-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-flume-bundle/pom.xml
@@ -18,10 +18,10 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-flume-bundle</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>A bundle of processors that run Flume sources/sinks</description>
     <modules>
@@ -33,7 +33,7 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-flume-processors</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-framework-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-administration/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-administration/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-administration</artifactId>
     <build>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-client-dto</artifactId>
     <dependencies>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-cluster-authorization-provider/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-cluster-authorization-provider/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-cluster-authorization-provider</artifactId>
     <dependencies>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-documentation/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-documentation</artifactId>
     <dependencies>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorization-provider/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-file-authorization-provider/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-file-authorization-provider</artifactId>
     <build>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-framework-cluster-protocol</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-web/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-web/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-framework-cluster-web</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-framework-cluster</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-framework-core-api</artifactId>
     <dependencies>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-framework-core</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-nar-utils</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-resources</artifactId>
     <packaging>pom</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-runtime/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-runtime</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-security/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-security/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-security</artifactId>
     <description>Contains security functionality common to NiFi.</description>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-site-to-site</artifactId>
     <dependencies>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-user-actions/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-user-actions/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-user-actions</artifactId>
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-custom-ui-utilities/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-custom-ui-utilities/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-web</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-custom-ui-utilities</artifactId>
     <dependencies>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-web</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-jetty</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-ui-extension/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-ui-extension/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-web</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-ui-extension</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-web</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-web-api</artifactId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-access/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-access/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-web</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-web-content-access</artifactId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-web</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-web-content-viewer</artifactId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-docs/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-docs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-web</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-web-docs</artifactId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-error/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-error/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-web</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-web-error</artifactId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-optimistic-locking/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-optimistic-locking/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-web</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-web-optimistic-locking</artifactId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-web</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-web-security</artifactId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-web</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-web-ui</artifactId>
     <packaging>war</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-web</artifactId>
     <packaging>pom</packaging>
@@ -40,31 +40,31 @@
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-web-api</artifactId>
                 <type>war</type>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-web-error</artifactId>
                 <type>war</type>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-web-docs</artifactId>
                 <type>war</type>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-web-content-viewer</artifactId>
                 <type>war</type>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-web-ui</artifactId>
                 <type>war</type>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-framework-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-framework</artifactId>
     <packaging>pom</packaging>

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-framework-bundle</artifactId>
     <packaging>pom</packaging>
@@ -31,92 +31,92 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-framework-cluster-protocol</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-framework-cluster-web</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-file-authorization-provider</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-cluster-authorization-provider</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-framework-cluster</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-runtime</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-client-dto</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-web-content-access</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-security</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-framework-core-api</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-site-to-site</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-framework-core</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-user-actions</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-administration</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-jetty</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-web-optimistic-locking</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-web-security</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-documentation</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-geo-bundle/nifi-geo-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-geo-bundle/nifi-geo-nar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-geo-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-geo-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-geo-bundle/nifi-geo-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-geo-bundle/nifi-geo-processors/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-geo-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-geo-processors</artifactId>
     <dependencies>

--- a/nifi-nar-bundles/nifi-geo-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-geo-bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-geo-bundle</artifactId>
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-geo-processors</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hadoop-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hadoop-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-hadoop-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-hadoop-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-hadoop-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-hdfs-processors</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-hadoop-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-hadoop-bundle</artifactId>
     <packaging>pom</packaging>
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-hdfs-processors</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/nifi-hadoop-libraries-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/nifi-hadoop-libraries-nar/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-hadoop-libraries-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-hadoop-libraries-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-hadoop-libraries-bundle</artifactId>

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-nar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-hbase-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-hbase-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-hbase-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-hbase-processors</artifactId>
     <description>Support for interacting with HBase</description>
@@ -27,13 +27,13 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hbase-client-service-api</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-distributed-cache-client-service-api</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-hbase-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hbase-bundle/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-hbase-bundle</artifactId>
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-hbase-processors</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.hbase</groupId>

--- a/nifi-nar-bundles/nifi-hl7-bundle/nifi-hl7-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-hl7-bundle/nifi-hl7-nar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-hl7-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-hl7-nar</artifactId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hl7-processors</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-hl7-bundle/nifi-hl7-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hl7-bundle/nifi-hl7-processors/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-hl7-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-hl7-processors</artifactId>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hl7-query-language</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
         
         <dependency>

--- a/nifi-nar-bundles/nifi-hl7-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hl7-bundle/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-hl7-bundle</artifactId>

--- a/nifi-nar-bundles/nifi-image-bundle/nifi-image-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-image-bundle/nifi-image-nar/pom.xml
@@ -19,23 +19,23 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-image-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-image-nar</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>nar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-image-processors</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-image-viewer</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
             <type>war</type>
         </dependency>
     </dependencies>

--- a/nifi-nar-bundles/nifi-image-bundle/nifi-image-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-image-bundle/nifi-image-processors/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-image-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-image-processors</artifactId>

--- a/nifi-nar-bundles/nifi-image-bundle/nifi-image-viewer/pom.xml
+++ b/nifi-nar-bundles/nifi-image-bundle/nifi-image-viewer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-image-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-image-viewer</artifactId>
     <description>NiFi image viewer</description>

--- a/nifi-nar-bundles/nifi-image-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-image-bundle/pom.xml
@@ -19,11 +19,11 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-image-bundle</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/nifi-nar-bundles/nifi-jetty-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-jetty-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-jetty-bundle</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-kafka-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-kafka-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-processors/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-kafka-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>nifi-kafka-processors</artifactId>

--- a/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-kafka-bundle</artifactId>
     <packaging>pom</packaging>
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-kafka-processors</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement> 

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-nar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-kite-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-kite-nar</artifactId>

--- a/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/nifi-kite-processors/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-kite-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-kite-processors</artifactId>

--- a/nifi-nar-bundles/nifi-kite-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kite-bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-kite-bundle</artifactId>
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-kite-processors</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-language-translation-bundle/nifi-language-translation-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-language-translation-bundle/nifi-language-translation-nar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-language-translation-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-language-translation-nar</artifactId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-yandex-processors</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-language-translation-bundle/nifi-yandex-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-language-translation-bundle/nifi-yandex-processors/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-language-translation-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-yandex-processors</artifactId>

--- a/nifi-nar-bundles/nifi-language-translation-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-language-translation-bundle/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-language-translation-bundle</artifactId>

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers-nar/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-ldap-iaa-providers-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-ldap-iaa-providers-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/pom.xml
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-ldap-iaa-providers-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-ldap-iaa-providers</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-ldap-iaa-providers-bundle</artifactId>
     <packaging>pom</packaging>
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-ldap-iaa-providers</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-nar/pom.xml
@@ -19,18 +19,18 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-mongodb-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-mongodb-nar</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>nar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mongodb-processors</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-mongodb-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-mongodb-processors</artifactId>

--- a/nifi-nar-bundles/nifi-mongodb-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-mongodb-bundle</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/pom.xml
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-provenance-repository-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-persistent-provenance-repository</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-provenance-repository-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-provenance-repository-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-provenance-repository-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-provenance-repository-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/pom.xml
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-provenance-repository-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-volatile-provenance-repository</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-provenance-repository-bundle</artifactId>
     <packaging>pom</packaging>
@@ -31,12 +31,12 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-persistent-provenance-repository</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-volatile-provenance-repository</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-social-media-bundle/nifi-social-media-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-social-media-bundle/nifi-social-media-nar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-social-media-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-social-media-nar</artifactId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-twitter-processors</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-social-media-bundle/nifi-twitter-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-social-media-bundle/nifi-twitter-processors/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-social-media-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-twitter-processors</artifactId>

--- a/nifi-nar-bundles/nifi-social-media-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-social-media-bundle/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-social-media-bundle</artifactId>

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-nar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-solr-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-solr-nar</artifactId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-solr-processors</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-solr-bundle/nifi-solr-processors/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-solr-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-solr-processors</artifactId>

--- a/nifi-nar-bundles/nifi-solr-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-solr-bundle/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-solr-bundle</artifactId>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-content-viewer/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-standard-content-viewer</artifactId>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-standard-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-prioritizers/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-prioritizers/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-standard-prioritizers</artifactId>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -14,7 +14,7 @@ language governing permissions and limitations under the License. -->
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-standard-processors</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-standard-reporting-tasks</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-standard-bundle</artifactId>
     <packaging>pom</packaging>
@@ -35,23 +35,23 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-standard-processors</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-standard-prioritizers</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-standard-reporting-tasks</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-standard-content-viewer</artifactId>
                 <type>war</type>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-api/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     
     <artifactId>nifi-dbcp-service-api</artifactId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-dbcp-service-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     
     <artifactId>nifi-dbcp-service-nar</artifactId>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-dbcp-service</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-dbcp-service-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-dbcp-service</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     
     <artifactId>nifi-dbcp-service-bundle</artifactId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-distributed-cache-client-service-api</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-distributed-cache-services-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-distributed-cache-client-service</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-protocol/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-protocol/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-distributed-cache-services-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-distributed-cache-protocol</artifactId>
     <description>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-distributed-cache-services-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-distributed-cache-server</artifactId>
     <description>Provides a Controller Service for hosting Distributed Caches</description>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-services-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-services-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-distributed-cache-services-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-distributed-cache-services-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-distributed-cache-services-bundle</artifactId>
     <packaging>pom</packaging>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-hbase-client-service-api</artifactId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service-nar/pom.xml
@@ -19,11 +19,11 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-hbase_1_1_2-client-service-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-hbase_1_1_2-client-service-nar</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>nar</packaging>
 
     <dependencies>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hbase_1_1_2-client-service</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/nifi-hbase_1_1_2-client-service/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-hbase_1_1_2-client-service-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-hbase_1_1_2-client-service</artifactId>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hbase-client-service-api</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.1-A-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_1_1_2-client-service-bundle/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-hbase_1_1_2-client-service-bundle</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-http-context-map-api/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-http-context-map-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
   
     <artifactId>nifi-http-context-map-api</artifactId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-http-context-map-bundle/nifi-http-context-map-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-http-context-map-bundle/nifi-http-context-map-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-http-context-map-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 	
     <artifactId>nifi-http-context-map-nar</artifactId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-http-context-map-bundle/nifi-http-context-map/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-http-context-map-bundle/nifi-http-context-map/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-http-context-map-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-http-context-map</artifactId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-http-context-map-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-http-context-map-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
 
     <artifactId>nifi-http-context-map-bundle</artifactId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-load-distribution-service-api/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-load-distribution-service-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-load-distribution-service-api</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-ssl-context-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-ssl-context-service-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-ssl-context-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-ssl-context-service</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-ssl-context-bundle</artifactId>
     <packaging>pom</packaging>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-service-api/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-service-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-ssl-context-service-api</artifactId>
     <packaging>jar</packaging>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-standard-services-api-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-standard-services-api-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-standard-services</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-standard-services-api-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-standard-services/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-standard-services</artifactId>
     <packaging>pom</packaging>

--- a/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-model/pom.xml
+++ b/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-model/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-update-attribute-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-update-attribute-model</artifactId>

--- a/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-nar/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-update-attribute-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-update-attribute-nar</artifactId>
     <packaging>nar</packaging>

--- a/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-processor/pom.xml
+++ b/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-processor/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-update-attribute-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-update-attribute-processor</artifactId>

--- a/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-ui/pom.xml
+++ b/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-ui/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-update-attribute-bundle</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-update-attribute-ui</artifactId>
     <packaging>war</packaging>

--- a/nifi-nar-bundles/nifi-update-attribute-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-update-attribute-bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-update-attribute-bundle</artifactId>
     <packaging>pom</packaging>
@@ -34,18 +34,18 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-update-attribute-model</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-update-attribute-processor</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-update-attribute-ui</artifactId>
                 <type>war</type>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/pom.xml
+++ b/nifi-nar-bundles/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.1-A-SNAPSHOT</version>
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-nar-bundles</artifactId>
@@ -55,81 +55,81 @@
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-distributed-cache-client-service</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-distributed-cache-client-service-api</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-ssl-context-service-api</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-load-distribution-service-api</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
              <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-http-context-map-api</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-distributed-cache-protocol</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-distributed-cache-server</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-ssl-context-service</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-http-context-map</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-volatile-provenance-repository</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
             <!-- The following dependencies are marked provided because they must be provided by the container.  Nars can assume they are there-->
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-api</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-runtime</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-nar-utils</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-properties</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ language governing permissions and limitations under the License. -->
     </parent>
     <groupId>org.apache.nifi</groupId>
     <artifactId>nifi</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.1-A-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.</description>
     <modules>
@@ -756,67 +756,67 @@ language governing permissions and limitations under the License. -->
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-api</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-utils</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-site-to-site-client</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-web-utils</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-expression-language</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-custom-ui-utilities</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-ui-extension</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-flowfile-packager</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-socket-utils</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-data-provenance-utils</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-runtime</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-bootstrap</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-resources</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <classifier>resources</classifier>
                 <scope>runtime</scope>
                 <type>zip</type>
@@ -824,7 +824,7 @@ language governing permissions and limitations under the License. -->
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-docs</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <classifier>resources</classifier>
                 <scope>runtime</scope>
                 <type>zip</type>
@@ -832,233 +832,233 @@ language governing permissions and limitations under the License. -->
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-framework-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-provenance-repository-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-standard-services-api-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-ssl-context-service-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-distributed-cache-services-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-standard-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-jetty-bundle</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-update-attribute-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-hadoop-libraries-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-hadoop-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-kite-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-mongodb-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-solr-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-kafka-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-http-context-map-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-social-media-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-hl7-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-language-translation-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-geo-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-aws-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-flume-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-dbcp-service-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-ambari-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-avro-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-image-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-couchbase-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-hbase_1_1_2-client-service-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-hbase-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-azure-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-ldap-iaa-providers-nar</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <type>nar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-properties</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-security-utils</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-logging-utils</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-nar-utils</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-processor-utils</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-mock</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-write-ahead-log</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-dbcp-service</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-dbcp-service-api</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>
                 <artifactId>nifi-hbase-client-service-api</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.1-A-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION
Name the version "0.4.1-A-SNAPSHOT" so that:

1) it is clear that Asymmertik has forked the NiFi 0.4.1 tag
2) retain SNAPSHOT so that we can continue to modify
