### PR TITLE
[NIFI-1145] Porting changes from NIFI-1145 to address test failures.

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/TestStandardFlowFileQueue.java
@@ -367,7 +367,7 @@ public class TestStandardFlowFileQueue {
         queue.poll(exp);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 120000)
     public void testDropSwappedFlowFiles() {
         for (int i = 1; i <= 210000; i++) {
             queue.put(new TestFlowFile());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/TestStandardControllerServiceProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/TestStandardControllerServiceProvider.java
@@ -117,7 +117,7 @@ public class TestStandardControllerServiceProvider {
      * {@link PropertyDescriptor}.isDependentServiceEnableable() as well as
      * https://issues.apache.org/jira/browse/NIFI-1143
      */
-    @Test(timeout = 10000)
+    @Test(timeout = 60000)
     public void testConcurrencyWithEnablingReferencingServicesGraph() {
         final ProcessScheduler scheduler = createScheduler();
         for (int i = 0; i < 1000; i++) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHttpSSL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestInvokeHttpSSL.java
@@ -47,6 +47,9 @@ public class TestInvokeHttpSSL extends TestInvokeHttpCommon {
         server = createServer();
         server.startServer();
 
+        // Allow time for the server to start
+        Thread.sleep(500);
+
         // this is the base url with the random port
         url = server.getSecureUrl();
     }
@@ -63,6 +66,13 @@ public class TestInvokeHttpSSL extends TestInvokeHttpCommon {
         runner.addControllerService("ssl-context", sslService, sslProperties);
         runner.enableControllerService(sslService);
         runner.setProperty(InvokeHTTP.PROP_SSL_CONTEXT_SERVICE, "ssl-context");
+
+        // Allow time for the controller service to fully initialize
+        Thread.sleep(500);
+
+        // Provide more time to setup and run
+        runner.setProperty(InvokeHTTP.PROP_READ_TIMEOUT, "30 secs");
+        runner.setProperty(InvokeHTTP.PROP_CONNECT_TIMEOUT, "30 secs");
 
         server.clearHandlers();
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenSyslog.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenSyslog.java
@@ -126,6 +126,9 @@ public class TestListenSyslog {
         final ProcessContext context = runner.getProcessContext();
         proc.onScheduled(context);
 
+        // Allow time for the processor to perform its scheduled start
+        Thread.sleep(500);
+
         final int numMessages = 20;
         final int port = proc.getPort();
         Assert.assertTrue(port > 0);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestServer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestServer.java
@@ -70,6 +70,8 @@ public class TestServer {
     private void createConnector() {
         final ServerConnector http = new ServerConnector(jetty);
         http.setPort(0);
+        // Severely taxed environments may have significant delays when executing
+        http.setIdleTimeout(30000L);
         jetty.addConnector(http);
     }
 
@@ -100,6 +102,9 @@ public class TestServer {
 
         // set host and port
         https.setPort(0);
+
+        // Severely taxed environments may have significant delays when executing.
+        https.setIdleTimeout(30000L);
 
         // add the connector
         jetty.addConnector(https);


### PR DESCRIPTION
Porting over changes from [NIFI-1145](https://issues.apache.org/jira/browse/NIFI-1145), which addresses unit test failures in certain environments due to timeout.
