### PR TITLE
Added alternate nifi assemblies

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -26,24 +26,73 @@ language governing permissions and limitations under the License. -->
                 <configuration>
                     <finalName>nifi-${project.version}</finalName>
                     <attach>true</attach>
+                    <tarLongFileMode>posix</tarLongFileMode>
+                    <archiverConfig>
+                        <defaultDirectoryMode>0775</defaultDirectoryMode>
+                        <directoryMode>0775</directoryMode>
+                        <fileMode>0664</fileMode>
+                    </archiverConfig>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>make shared resource</id>
+                        <id>make complete assembly</id>
                         <goals>
                             <goal>single</goal>
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <archiverConfig>
-                                <defaultDirectoryMode>0775</defaultDirectoryMode>
-                                <directoryMode>0775</directoryMode>
-                                <fileMode>0664</fileMode>
-                            </archiverConfig>
                             <descriptors>
                                 <descriptor>src/main/assembly/dependencies.xml</descriptor>
                             </descriptors>
                             <tarLongFileMode>posix</tarLongFileMode>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>make bare container assembly</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/container.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>make primary nars assembly</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/nars-primary.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>make secondary nars assembly</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/nars-secondary.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>make all nars assembly</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/nars-all.xml</descriptor>
+                            </descriptors>
                         </configuration>
                     </execution>
                 </executions>
@@ -142,7 +191,6 @@ language governing permissions and limitations under the License. -->
             <artifactId>nifi-update-attribute-nar</artifactId>
             <type>nar</type>
         </dependency>
-<!--
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hadoop-libraries-nar</artifactId>
@@ -153,7 +201,6 @@ language governing permissions and limitations under the License. -->
             <artifactId>nifi-hadoop-nar</artifactId>
             <type>nar</type>
         </dependency>
--->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-kafka-nar</artifactId>
@@ -174,7 +221,6 @@ language governing permissions and limitations under the License. -->
             <artifactId>nifi-html-nar</artifactId>
             <type>nar</type>
         </dependency>
-<!--
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-kite-nar</artifactId>
@@ -200,13 +246,11 @@ language governing permissions and limitations under the License. -->
             <artifactId>nifi-dbcp-service-nar</artifactId>
             <type>nar</type>
         </dependency>
--->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mongodb-nar</artifactId>
             <type>nar</type>
         </dependency>
-<!--
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-solr-nar</artifactId>
@@ -232,13 +276,11 @@ language governing permissions and limitations under the License. -->
             <artifactId>nifi-geo-nar</artifactId>
             <type>nar</type>
         </dependency>
--->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-aws-nar</artifactId>
             <type>nar</type>
         </dependency>
-<!--
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-ambari-nar</artifactId>
@@ -279,7 +321,6 @@ language governing permissions and limitations under the License. -->
             <artifactId>nifi-azure-nar</artifactId>
             <type>nar</type>
         </dependency>
--->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-scripting-nar</artifactId>
@@ -290,7 +331,6 @@ language governing permissions and limitations under the License. -->
             <artifactId>nifi-elasticsearch-nar</artifactId>
             <type>nar</type>
         </dependency>
-<!--
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-lumberjack-nar</artifactId>
@@ -331,13 +371,11 @@ language governing permissions and limitations under the License. -->
             <artifactId>nifi-hive-nar</artifactId>
             <type>nar</type>
         </dependency>
--->
 	    <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-site-to-site-reporting-nar</artifactId>
             <type>nar</type>
       	</dependency>
-<!--
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mqtt-nar</artifactId>
@@ -348,7 +386,6 @@ language governing permissions and limitations under the License. -->
             <artifactId>nifi-snmp-nar</artifactId>
             <type>nar</type>
         </dependency>
--->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-slack-nar</artifactId>

--- a/nifi-assembly/src/main/assembly/container.xml
+++ b/nifi-assembly/src/main/assembly/container.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<assembly>
+    <id>container</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>nifi-${project.version}</baseDirectory>
+
+    <dependencySets>
+        <!-- Write out dependency artifacts to lib directory -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>lib</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0660</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <useStrictFiltering>true</useStrictFiltering>
+            <includes>
+                <include>jcl-over-slf4j</include>
+                <include>jul-to-slf4j</include>
+                <include>log4j-over-slf4j</include>
+                <include>logback-classic</include>
+                <include>nifi-api</include>
+                <include>nifi-framework-nar</include>
+                <include>nifi-jetty-bundle</include>
+                <include>nifi-provenance-repository-nar</include>
+                <include>nifi-runtime</include>
+                <include>slf4j-api</include>
+            </includes>
+        </dependencySet>
+        
+        <!-- Write out the bootstrap lib component to its own dir -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>lib/bootstrap</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0660</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+            	<include>nifi-bootstrap</include>
+            	<include>slf4j-api</include>
+            	<include>logback-classic</include>
+            	<include>nifi-api</include>
+            </includes>
+        </dependencySet>
+        
+        <!-- Write out the conf directory contents -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>./</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0664</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+            	<include>nifi-resources</include>
+            </includes>
+            <unpack>true</unpack>
+            <unpackOptions>
+                <filtered>true</filtered>
+                <includes>
+                    <include>conf/*</include>
+                </includes>
+            </unpackOptions>
+        </dependencySet>
+
+        <!-- Write out the bin directory contents -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>./</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0770</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+            	<include>nifi-resources</include>
+            </includes>
+            <unpack>true</unpack>
+            <unpackOptions>
+                <filtered>true</filtered>
+                <includes>
+                    <include>bin/*</include>
+                </includes>
+            </unpackOptions>
+        </dependencySet>
+        
+        <!-- Writes out the docs directory contents -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>docs/</outputDirectory>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+            	<include>nifi-docs</include>
+            </includes>
+            <unpack>true</unpack>
+            <unpackOptions>
+                <filtered>false</filtered>
+                <excludes>
+                  <!-- LICENSE and NOTICE both covered by top-level -->
+                  <exclude>LICENSE</exclude>
+                  <exclude>NOTICE</exclude>
+                </excludes>
+            </unpackOptions>
+        </dependencySet>                
+    </dependencySets>
+    <files>
+        <file>
+            <source>./README.md</source>
+            <outputDirectory>./</outputDirectory>
+            <destName>README</destName>
+            <fileMode>0644</fileMode>
+            <filtered>true</filtered>
+        </file>
+        <file>
+            <source>./LICENSE</source>
+            <outputDirectory>./</outputDirectory>
+            <destName>LICENSE</destName>
+            <fileMode>0644</fileMode>
+            <filtered>true</filtered>
+        </file>       
+        <file>
+            <source>./NOTICE</source>
+            <outputDirectory>./</outputDirectory>
+            <destName>NOTICE</destName>
+            <fileMode>0644</fileMode>
+            <filtered>true</filtered>
+        </file>
+    </files>
+</assembly>

--- a/nifi-assembly/src/main/assembly/nars-all.xml
+++ b/nifi-assembly/src/main/assembly/nars-all.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<assembly>
+    <id>nars-all</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>nifi-${project.version}</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>/</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0660</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <useStrictFiltering>true</useStrictFiltering>
+            <includes>
+                <include>*:*:nar</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+</assembly>
+

--- a/nifi-assembly/src/main/assembly/nars-primary.xml
+++ b/nifi-assembly/src/main/assembly/nars-primary.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<assembly>
+    <id>nars-primary</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>nifi-${project.version}</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>/</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0660</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <useStrictFiltering>true</useStrictFiltering>
+            <includes>
+                <!-- standard -->
+            	<include>nifi-standard-services-api-nar</include>
+            	<include>nifi-ssl-context-service-nar</include>
+            	<include>nifi-distributed-cache-services-nar</include>
+            	<include>nifi-standard-nar</include>
+            	<include>nifi-update-attribute-nar</include>
+            	<include>nifi-http-context-map-nar</include>
+            	<include>nifi-html-nar</include>
+            	<include>nifi-scripting-nar</include>
+                <!-- extras -->
+            	<include>nifi-mongodb-nar</include>
+            	<include>nifi-aws-nar</include>
+            	<include>nifi-elasticsearch-nar</include>
+            	<include>nifi-kafka-nar</include>
+            	<include>nifi-kafka-pubsub-nar</include>
+            	<include>nifi-slack-nar</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+</assembly>
+

--- a/nifi-assembly/src/main/assembly/nars-secondary.xml
+++ b/nifi-assembly/src/main/assembly/nars-secondary.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<assembly>
+    <id>nars-secondary</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>nifi-${project.version}</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>/</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0660</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <useStrictFiltering>true</useStrictFiltering>
+            <includes>
+            	<include>nifi-hadoop-libraries-nar</include>
+            	<include>nifi-hadoop-nar</include>
+            	<include>nifi-kite-nar</include>
+            	<include>nifi-flume-nar</include>
+            	<include>nifi-ldap-iaa-providers-nar</include>
+            	<include>nifi-kerberos-iaa-providers-nar</include>
+            	<include>nifi-dbcp-service-nar</include>
+            	<include>nifi-solr-nar</include>
+            	<include>nifi-social-media-nar</include>
+            	<include>nifi-hl7-nar</include>
+            	<include>nifi-language-translation-nar</include>
+            	<include>nifi-geo-nar</include>
+            	<include>nifi-ambari-nar</include>
+            	<include>nifi-avro-nar</include>
+            	<include>nifi-media-nar</include>
+            	<include>nifi-couchbase-nar</include>
+            	<include>nifi-hbase-nar</include>
+            	<include>nifi-riemann-nar</include>
+            	<include>nifi-hbase_1_1_2-client-service-nar</include>
+            	<include>nifi-azure-nar</include>
+            	<include>nifi-lumberjack-nar</include>
+            	<include>nifi-amqp-nar</include>
+            	<include>nifi-splunk-nar</include>
+            	<include>nifi-jms-cf-service-nar</include>
+            	<include>nifi-jms-processors-nar</include>
+            	<include>nifi-cassandra-nar</include>
+            	<include>nifi-spring-nar</include>
+            	<include>nifi-hive-nar</include>
+            	<include>nifi-mqtt-nar</include>
+            	<include>nifi-snmp-nar</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+</assembly>
+


### PR DESCRIPTION
Create several alternate assemblies, in addition to the complete NiFi assembly, to facilitate more flexible deployments:
- container - base container containing what what is absolutely necessary to start NiFi; contains no processors/services
- nars-all - all nars
- nars-primary - standard nars along with common "extra" nars such as mongo, kafka, aws, elasticsearch, slack
- nars-secondary - all nars that are not included in primary

Also reverts an earlier change to slim down the complete assembly as that will no longer be used.
