### PR TITLE
A-3128 Shaded nifi-aws-processors jar, other tweaks

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
@@ -67,6 +67,38 @@
                     </excludes>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <configuration>
+                    <artifactSet>
+                        <includes>
+                            <include>nifi-aws-processors</include>
+                        </includes>
+                    </artifactSet>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>classes</shadedClassifierName>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                            <resources>
+                                <resource>org.apache.nifi.controller.ControllerService</resource>
+                                <resource>org.apache.nifi.processor.Processor</resource>
+                            </resources>
+                        </transformer>
+                    </transformers>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
 import com.amazonaws.services.cloudwatch.model.StatisticSet;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -264,7 +265,9 @@ public class PutCloudWatchMetric extends AbstractAWSCredentialsProviderProcessor
             List<Dimension> dimensions = new ArrayList<>(dynamicPropertyNames.size());
             for (String propertyName : dynamicPropertyNames) {
                 String propertyValue = context.getProperty(propertyName).evaluateAttributeExpressions(flowFile).getValue();
-                dimensions.add(new Dimension().withName(propertyName).withValue(propertyValue));
+                if (StringUtils.isNotBlank(propertyValue)) {
+                    dimensions.add(new Dimension().withName(propertyName).withValue(propertyValue));
+                }
             }
             dataum.withDimensions(dimensions);
         }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
@@ -101,7 +101,7 @@ public class PutEmail extends AbstractProcessor {
             .expressionLanguageSupported(true)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .required(false)
-            .sensitive(true)
+            //.sensitive(true)
             .build();
     public static final PropertyDescriptor SMTP_AUTH = new PropertyDescriptor.Builder()
             .name("SMTP Auth")

--- a/pom.xml
+++ b/pom.xml
@@ -1712,7 +1712,7 @@ language governing permissions and limitations under the License. -->
                             <goals>deploy</goals>
                             <tagNameFormat>asymmetrik/@{project.artifactId}-@{project.version}</tagNameFormat>
                             <!-- skip maven-gpg-plugin -->
-                            <arguments>-Dgpg.skip=true</arguments>
+                            <arguments>-Dgpg.skip=true -Dmaven.test.skip=true</arguments>
                             <releaseProfiles />
                             <pushChanges>true</pushChanges>
                             <localCheckout>false</localCheckout>


### PR DESCRIPTION
- Create a shaded nifi-aws-processors jar for use as a dependency
- Do not allow empty dimension values in PutCloudWatchMetric
- Remove sensitive on PutEmail password to allow storing expression language in template
- Skip test compilation on releasing
